### PR TITLE
Harden GitHub Actions tool install and deployment

### DIFF
--- a/.ci/github-actions.sh
+++ b/.ci/github-actions.sh
@@ -40,7 +40,9 @@ GALAXY_TEMPLATE_DB='galaxy.sqlite'
 
 # Set by Actions, so the defaults here are for development
 GIT_COMMIT="${GITHUB_SHA:-$(git rev-parse HEAD)}"
-RUN_ID="${GITHUB_RUN_ID:-$$}"
+# GITHUB_RUN_ID is stable across re-runs, while GITHUB_RUN_ATTEMPT increments for each attempt.
+RUN_ID="${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-1}"
+DOCKER_RUN_LABEL='org.galaxyproject.usegalaxy-tools.runner-managed=true'
 
 # Per-run scratch dir and the log dir within it that the workflow uploads as an artifact
 RUN_DIR="${SCRATCH_ROOT}/${RUN_ID}"
@@ -435,7 +437,7 @@ function start_ssh_control() {
     SSH_MASTER_SOCKET="${SSH_MASTER_SOCKET_DIR}/ssh-tunnel-${REPO_USER}-${REPO_STRATUM0}.sock"
     log_exec mkdir -p "$SSH_MASTER_SOCKET_DIR"
     $USE_LOCAL_OVERLAYFS || port_forward_flag="-L 127.0.0.1:${LOCAL_PORT}:127.0.0.1:${REMOTE_PORT}"
-    log_exec ssh -o StrictHostKeyChecking=accept-new -o HashKnownHosts=no -S "$SSH_MASTER_SOCKET" -M ${port_forward_flag:-} -Nfn -l "$REPO_USER" "$REPO_STRATUM0"
+    log_exec ssh -o StrictHostKeyChecking=yes -S "$SSH_MASTER_SOCKET" -M ${port_forward_flag:-} -Nfn -l "$REPO_USER" "$REPO_STRATUM0"
     USER_UID=$(exec_on id -u)
     USER_GID=$(exec_on id -g)
     SSH_MASTER_UP=true
@@ -535,7 +537,7 @@ function run_container_for_preconfigure() {
     PRECONFIGURED_IMAGE_NAME="${PRECONFIGURE_CONTAINER_NAME}d"
     ORIGINAL_IMAGE_NAME="$GALAXY_DOCKER_IMAGE"
     log "Starting Galaxy container for preconfiguration on Stratum 0"
-    exec_on docker run -d --name="$PRECONFIGURE_CONTAINER_NAME" \
+    exec_on docker run -d --label "$DOCKER_RUN_LABEL" --name="$PRECONFIGURE_CONTAINER_NAME" \
         -v "${WORKDIR}/:/work/" \
         $source_mount_flag \
         -v "${GALAXY_DATABASE_TMPDIR}:/galaxy/server/database" \
@@ -588,7 +590,7 @@ function run_mounted_galaxy() {
 
     if [ -n "$GALAXY_TEMPLATE_DB_URL" ]; then
         log "Updating database"
-        exec_on docker run --rm --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}-setup" \
+        exec_on docker run --rm --label "$DOCKER_RUN_LABEL" --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}-setup" \
             -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/${GALAXY_TEMPLATE_DB}" \
             -v "${GALAXY_SOURCE_TMPDIR}:/galaxy/server" \
             -v "${GALAXY_DATABASE_TMPDIR}:/galaxy/server/database" \
@@ -597,7 +599,7 @@ function run_mounted_galaxy() {
     fi
 
     log "Starting Galaxy on Stratum 0"
-    exec_on docker run -d -p 127.0.0.1:${REMOTE_PORT}:8080 --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}" \
+    exec_on docker run -d --label "$DOCKER_RUN_LABEL" -p 127.0.0.1:${REMOTE_PORT}:8080 --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}" \
         -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/${GALAXY_TEMPLATE_DB}" \
         -e "GALAXY_CONFIG_OVERRIDE_INTEGRATED_TOOL_PANEL_CONFIG=/tmp/integrated_tool_panel.xml" \
         -e "GALAXY_CONFIG_OVERRIDE_SHED_TOOL_CONFIG_FILE=${SHED_TOOL_CONFIG}" \
@@ -628,7 +630,7 @@ function run_cloudve_galaxy() {
 
     if [ -n "$GALAXY_TEMPLATE_DB_URL" ]; then
         log "Updating database"
-        exec_on docker run --rm --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}-setup" \
+        exec_on docker run --rm --label "$DOCKER_RUN_LABEL" --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}-setup" \
             -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/${GALAXY_TEMPLATE_DB}" \
             -v "${GALAXY_DATABASE_TMPDIR}:/galaxy/server/database" \
             "$GALAXY_DOCKER_IMAGE" ./.venv/bin/python ./scripts/manage_db.py upgrade
@@ -636,7 +638,7 @@ function run_cloudve_galaxy() {
 
     # we could just start the patch container and run Galaxy in it with `docker exec`, but then logs aren't captured
     log "Starting Galaxy on Stratum 0"
-    exec_on docker run -d -p 127.0.0.1:${REMOTE_PORT}:8080 --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}" \
+    exec_on docker run -d --label "$DOCKER_RUN_LABEL" -p 127.0.0.1:${REMOTE_PORT}:8080 --user "${USER_UID}:${USER_GID}" --name="${CONTAINER_NAME}" \
         -e "GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=sqlite:////galaxy/server/database/${GALAXY_TEMPLATE_DB}" \
         -e "GALAXY_CONFIG_OVERRIDE_INTEGRATED_TOOL_PANEL_CONFIG=/tmp/integrated_tool_panel.xml" \
         -e "GALAXY_CONFIG_OVERRIDE_SHED_TOOL_CONFIG_FILE=${SHED_TOOL_CONFIG}" \
@@ -669,7 +671,7 @@ function run_bgruening_galaxy() {
     log "Copying additional configs to Stratum 0"
     copy_to ".ci/nginx.conf"
     log "Starting Galaxy on Stratum 0"
-    exec_on docker run -d -p 127.0.0.1:${REMOTE_PORT}:80 --name="${CONTAINER_NAME}" \
+    exec_on docker run -d --label "$DOCKER_RUN_LABEL" -p 127.0.0.1:${REMOTE_PORT}:80 --name="${CONTAINER_NAME}" \
         -e "GALAXY_CONFIG_INSTALL_DATABASE_CONNECTION=sqlite:///${INSTALL_DATABASE}" \
         -e "GALAXY_CONFIG_SHED_TOOL_CONFIG_FILE=${SHED_TOOL_CONFIG}" \
         -e "GALAXY_CONFIG_MASTER_API_KEY=${API_KEY:=deadbeef}" \

--- a/.ci/runner-job-started.sh
+++ b/.ci/runner-job-started.sh
@@ -13,15 +13,23 @@ set -uo pipefail
 
 : ${SCRATCH_ROOT:=/data/actions-runner/scratch}
 
-# Run dirs older than this are removed even if idle, in case a run dir was orphaned without a mount
-MAX_AGE_DAYS=1
+DOCKER_RUN_LABEL='org.galaxyproject.usegalaxy-tools.runner-managed=true'
 
 log() {
     echo "[runner-job-started] $*"
 }
 
+# Detached containers survive if the job is forcibly terminated. Remove them before unmounting their bind mounts.
+if command -v docker >/dev/null 2>&1; then
+    while read -r container_id; do
+        [ -n "$container_id" ] || continue
+        log "Removing stale container: ${container_id}"
+        docker rm -f "$container_id" || log "WARNING: could not remove container ${container_id}"
+    done < <(docker ps -aq --filter "label=${DOCKER_RUN_LABEL}" 2>/dev/null)
+fi
+
 [ -d "$SCRATCH_ROOT" ] || {
-    log "${SCRATCH_ROOT} does not exist, nothing to clean"
+    log "${SCRATCH_ROOT} does not exist, no scratch state to clean"
     exit 0
 }
 
@@ -37,18 +45,16 @@ while read -r mountpoint; do
         || log "WARNING: could not unmount ${mountpoint}"
 done < <(findmnt -rno TARGET | grep "^${SCRATCH_ROOT}/" | sort -r)
 
-# Remove run dirs that no longer contain a mount. Anything still mounted is left alone: a subsequent job gets a fresh
-# $GITHUB_RUN_ID and so its own run dir, and the mount should be reapable on a later pass.
+# Remove run dirs that no longer contain a mount. Completed-job logs have already been uploaded, and canceled jobs must
+# not leave an overlay upper/work directory that a re-run could reuse.
 for run_dir in "$SCRATCH_ROOT"/*; do
     [ -d "$run_dir" ] || continue
     if findmnt -rno TARGET | grep -q "^${run_dir}\(/\|$\)"; then
         log "Leaving ${run_dir}, still has a mount under it"
         continue
     fi
-    if [ -n "$(find "$run_dir" -maxdepth 0 -mtime "+${MAX_AGE_DAYS}")" ]; then
-        log "Removing stale run dir: ${run_dir}"
-        rm -rf "$run_dir" || log "WARNING: could not remove ${run_dir}"
-    fi
+    log "Removing stale run dir: ${run_dir}"
+    rm -rf "$run_dir" || log "WARNING: could not remove ${run_dir}"
 done
 
 exit 0

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,7 @@
 # Galaxy Project US servers
 usegalaxy.org/*             @galaxyproject/tool-installers
 test.galaxyproject.org/*    @galaxyproject/tool-installers
+
+# CI pipeline and repository configuration require admin review, not just tool-installer review
+/.ci/                       @galaxyproject/tool-installers-admins
+/.github/                   @galaxyproject/tool-installers-admins

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 TODO: Please replace this header with a description of your pull request.
 
 ## Installation sequence for `tool-installers`
-- [ ] Test using `@galaxybot test this`
-- [ ] Inspect CI output for expected changes
-- [ ] Deploy using `@galaxybot deploy this` if test install was successful
-- [ ] Merge this PR
+- [ ] Inspect the automatic *Test tool installation* summary for the expected changes
+- [ ] Merge this PR if the test installation succeeded
+- [ ] Inspect the post-merge *Deploy tools to CVMFS* summary and bot result comment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,22 +17,21 @@ permissions:
   contents: read
   pull-requests: write
 
-# Serialize deploys: three of the four toolsets publish to the same Stratum 0, and concurrent CVMFS transactions
-# collide. Never cancel a deploy in progress, that is how an open transaction gets stranded.
-concurrency:
-  group: cvmfs-publish
-  cancel-in-progress: false
+# Keep exactly one runner in the cvmfs-publish group. Its normal runner queue preserves every deploy while serializing
+# the CVMFS transactions; a concurrency group would discard older pending runs when several PRs merge close together.
 
 jobs:
   deploy:
     if: github.event.pull_request.merged == true
-    runs-on: [self-hosted, cvmfs]
-    # Scopes STRATUM0_SSH_KEY to this job, so other workflows on this runner cannot reach it
+    runs-on:
+      group: cvmfs-publish
+      labels: cvmfs
+    # Requests the protected publish environment; its required reviewers are the deployment authorization gate.
     environment: cvmfs-publish
     timeout-minutes: 180
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
@@ -47,7 +46,7 @@ jobs:
           printf '%s\n' "$STRATUM0_SSH_KEY" | ssh-add -
 
       - name: Comment that the deploy has started
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -66,7 +65,7 @@ jobs:
         run: .ci/github-actions.sh
 
       - name: Comment the deploy result
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: always()
         with:
           script: |
@@ -95,7 +94,7 @@ jobs:
         run: ssh-agent -k || true
 
       - name: Upload Galaxy log
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: galaxy-log

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
@@ -46,7 +46,7 @@ jobs:
           printf '%s\n' "$STRATUM0_SSH_KEY" | ssh-add -
 
       - name: Comment that the deploy has started
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -65,7 +65,7 @@ jobs:
         run: .ci/github-actions.sh
 
       - name: Comment the deploy result
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@v9
         if: always()
         with:
           script: |
@@ -94,7 +94,7 @@ jobs:
         run: ssh-agent -k || true
 
       - name: Upload Galaxy log
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: galaxy-log

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -21,7 +21,7 @@ jobs:
       tool_changes: ${{ steps.detect.outputs.tool_changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@v7
         with:
           # detect_changes diffs the PR against its merge base, so the full history is needed
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
         run: .ci/github-actions.sh
 
       - name: Upload Galaxy log
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: galaxy-log

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -5,10 +5,6 @@ name: Test tool installation
 on:
   pull_request:
     branches: ["master"]
-    paths:
-      - 'usegalaxy.org/**'
-      - 'test.galaxyproject.org/**'
-      - 'cloud/**'
 
 permissions:
   contents: read
@@ -18,12 +14,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-install:
-    runs-on: [self-hosted, cvmfs]
+  changes:
+    name: Detect tool changes
+    runs-on: ubuntu-latest
+    outputs:
+      tool_changes: ${{ steps.detect.outputs.tool_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect tool changes
+        id: detect
+        env:
+          COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --quiet "$COMMIT_RANGE" -- usegalaxy.org/ test.galaxyproject.org/ cloud/; then
+            echo 'tool_changes=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'tool_changes=true' >> "$GITHUB_OUTPUT"
+          fi
+
+  test-install-run:
+    name: Test tool installation
+    needs: changes
+    if: needs.changes.outputs.tool_changes == 'true'
+    runs-on:
+      group: cvmfs-test
+      labels: cvmfs
     timeout-minutes: 120
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # detect_changes diffs the PR against its merge base, so the full history is needed
           fetch-depth: 0
@@ -35,9 +58,32 @@ jobs:
         run: .ci/github-actions.sh
 
       - name: Upload Galaxy log
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: galaxy-log
           path: ${{ env.CI_LOG_DIR }}
           if-no-files-found: ignore
+
+  # This job always reports the required check, including on PRs without tool changes. Keep the privileged runner job
+  # conditional so documentation-only changes never consume it.
+  test-install:
+    name: test-install
+    needs: [changes, test-install-run]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify test-install result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          TOOL_CHANGES: ${{ needs.changes.outputs.tool_changes }}
+          INSTALL_RESULT: ${{ needs.test-install-run.result }}
+        run: |
+          if [ "$CHANGES_RESULT" != success ]; then
+            echo 'Tool change detection failed' >&2
+            exit 1
+          fi
+          if [ "$TOOL_CHANGES" = true ] && [ "$INSTALL_RESULT" != success ]; then
+            echo "Test installation did not succeed: $INSTALL_RESULT" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Before proceeding with deployment, ensure the following preconditions on a PR ar
 
 Once preconditions are met:
 
-1. **The test installation runs automatically** when the PR is opened or updated (*Test tool installation*). For a PR from a fork by someone outside the organization, a tool installer has to approve the run first.
+1. **The test installation runs automatically** when the PR is opened or updated (*Test tool installation*). For a PR from a fork by someone outside the organization, an authorized maintainer has to approve the run first.
 2. **Review the run summary.** Just because it is green does not mean it succeeded. Open the workflow run and look for two things:
    1. **Contents of OverlayFS upper mount (will be published)** contains (at least) `config/shed_tool_conf.xml` and `shed_tools/.../the_repos_you_installed`
    2. **Diff of shed_tool_conf.xml** contains the tools in the repos you installed

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -2,9 +2,10 @@
 
 Tool installation needs to mount CVMFS and stack a `fuse-overlayfs` on top of it, which
 GitHub-hosted runners do not permit. `.github/workflows/test-install.yml` and
-`.github/workflows/deploy.yml` therefore run on a self-hosted runner labeled `cvmfs`.
+`.github/workflows/deploy.yml` therefore run on isolated self-hosted runners labeled `cvmfs`.
 
-This document covers provisioning that runner and the repository settings it depends on.
+This document covers provisioning those runners and the repository settings they depend on. The PR-test and publish
+jobs must never share a host: PR code is untrusted even after a workflow run is approved.
 
 ## Host requirements
 
@@ -17,7 +18,7 @@ This document covers provisioning that runner and the repository settings it dep
 | `python3` with `venv` | `setup_ephemeris` builds a virtualenv per run. |
 | `git`, `rsync`, `curl`, `tree`, `psmisc` | `rsync` copies the overlay upper dir to the Stratum 0; `tree` and `fuser` (from `psmisc`) are used when reporting and unmounting. |
 
-Run the runner as a **dedicated non-root user**. It must be able to create files inside the
+Run each runner as a **dedicated non-root user**. It must be able to create files inside the
 overlay from within the Galaxy container — see the `FIXME: unprivileged would be preferable` note
 in `.ci/github-actions.sh`, which is why `fuse-overlayfs` is mounted with `allow_root`.
 
@@ -45,63 +46,58 @@ needs. A cold cache costs one slow run, nothing worse.
 The deploy job opens an SSH control connection to the Stratum 0 to run `cvmfs_server transaction`
 and `cvmfs_server publish`, and to `rsync` the overlay upper dir across.
 
-- **Host keys need no setup.** The control connection is opened with
-  `StrictHostKeyChecking=accept-new`, so the Stratum 0 key is recorded in the runner user's
-  `~/.ssh/known_hosts` on first connect and verified on every deploy after that. If a Stratum 0 is
-  ever rebuilt, deploys to it will fail until the stale entry is removed with `ssh-keygen -R`,
-  which is the intended behaviour — a changed host key should stop a publish, not be accepted
-  silently.
+- **Provision host keys before the first deploy.** Install keys whose fingerprints were verified out of band in the
+  publish runner user's `~/.ssh/known_hosts` or the system `ssh_known_hosts`. The control connection uses
+  `StrictHostKeyChecking=yes`, so an absent or changed key stops the deploy.
 - **The private key is not stored on the runner.** It lives in the `cvmfs-publish` environment as
   the `STRATUM0_SSH_KEY` secret and is loaded into an `ssh-agent` for the life of the deploy job
-  only. This is the point of using an environment: another workflow scheduled onto the same runner
-  cannot reach the key. The agent is killed in an `if: always()` step, which matters on a
-  persistent runner — a leaked agent would be a leaked key for every job that follows.
+  only. The publish runner group only permits the default-branch deploy workflow, and required environment reviewers
+  provide a separate authorization gate. The agent is killed in an `if: always()` step.
 
 ## Runner registration
 
-Register the runner **to this repository**, not to the organization, with labels:
+Create two **organization-level runner groups** that allow only selected workflows:
+
+- `cvmfs-test` allows only `galaxyproject/usegalaxy-tools/.github/workflows/test-install.yml`.
+- `cvmfs-publish` allows only `galaxyproject/usegalaxy-tools/.github/workflows/deploy.yml` from the default branch.
+
+Register separate hosts in the two groups with the labels `self-hosted, Linux, X64, cvmfs`. Do not place a host in
+both groups. The test host executes PR-controlled code, so give it no secrets or SSH/write access to Stratum 0; allow
+only the read-only HTTP access needed by the CVMFS client. Rebuild it from a clean image after untrusted runs. Keep
+exactly one runner in the publish group so its runner queue serializes every deploy without dropping pending runs. The
+publish host must never accept a `pull_request` job.
+
+Install the job-started hook on each host. It removes labeled Galaxy containers, mounts, and scratch directories left
+behind when a job is forcibly terminated:
 
 ```
-self-hosted, Linux, X64, cvmfs
+ACTIONS_RUNNER_HOOK_JOB_STARTED=/opt/actions-runner-hooks/usegalaxy-tools-job-started.sh
 ```
 
-Install the job-started hook, which cleans up mounts and scratch directories left behind when a
-job is cancelled or times out (the runner SIGKILLs the job, so the script's trap handler never
-runs):
-
-```
-ACTIONS_RUNNER_HOOK_JOB_STARTED=/path/to/usegalaxy-tools/.ci/runner-job-started.sh
-```
-
-Set it in the runner's `.env` file. If `SCRATCH_ROOT` is not the default, export it there too so
-the hook cleans the right directory.
+Copy the hook from `.ci/runner-job-started.sh` to that root- or configuration-management-owned path; do not execute a
+hook from a repository checkout that a PR can modify. Set it in the runner's `.env` file. If `SCRATCH_ROOT` is not the
+default, export it there too so the hook cleans the right directory. Run only one runner service per host and scratch
+root, because a job-started hook assumes that every existing run directory is stale.
 
 ## Repository settings
 
 - **Settings → Actions → General**
-  - Fork pull request workflows: *Require approval for all external contributors*. This is what
-    keeps a public repo's PRs from running arbitrary code on a privileged runner.
+  - Fork pull request workflows: *Require approval for all external contributors*. Approval controls scheduling; it
+    does not make PR code trusted, which is why the test runner is isolated from publishing.
   - Workflow permissions: read-only by default.
+  - After migrating the repository's existing workflows, require actions to be pinned to a full-length commit SHA.
 - **Settings → Environments → `cvmfs-publish`**
   - Secret `STRATUM0_SSH_KEY` — the private key authorized on the Stratum 0 hosts.
-  - No required reviewers: merge permission is already the gate, and a second approval click after
-    merge would only re-confirm a decision the same people just made.
+  - Add `@galaxyproject/tool-installers` as required reviewers and prevent self-review. This is the deploy authorization
+    gate; ordinary merge permission is not sufficient.
 - **Settings → Branches → branch protection for `master`**
-  - Require the `test-install` check to pass before merging. This replaces the convention of
-    "merge only once you've verified the console output" with something actually enforced.
+  - Require the `test-install` check to pass before merging. The check always reports, including for PRs without tool
+    changes; only its privileged installation dependency is conditional.
+  - Require pull requests and CODEOWNER approval, including for `.github/workflows/` and `.ci/`, without administrator
+    bypass.
   - **Disable rebase merging.** The deploy workflow derives the PR's changes from
     `<merge_commit_sha>^1...<merge_commit_sha>`, which is correct for merge commits and squashes
     but not for rebase merges, where it would see only the PR's last commit.
-
-### A caveat worth stating plainly
-
-A repository-scoped runner can be targeted by *any* workflow in the repository — the "allow
-selected workflows" control is a runner **group** feature, and runner groups are only available to
-organizations and enterprises. The real protections here are the fork-approval setting above and
-branch protection on `.github/workflows/`, plus keeping the Stratum 0 key in an environment rather
-than on the runner's disk. Since only members of `@galaxyproject/tool-installers` and org admins
-can approve fork PR runs or merge, this is adequate — but it is a policy control, not a technical
-one, so it should be understood rather than assumed.
 
 ## Verifying the runner
 
@@ -111,9 +107,11 @@ a throwaway workflow that does nothing but mount and unmount:
 ```yaml
 jobs:
   smoke:
-    runs-on: [self-hosted, cvmfs]
+    runs-on:
+      group: cvmfs-test
+      labels: cvmfs
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: |
           set -euo pipefail
           export REPO_STRATUM0=cvmfs0-psu1.galaxyproject.org

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -85,7 +85,6 @@ root, because a job-started hook assumes that every existing run directory is st
   - Fork pull request workflows: *Require approval for all external contributors*. Approval controls scheduling; it
     does not make PR code trusted, which is why the test runner is isolated from publishing.
   - Workflow permissions: read-only by default.
-  - After migrating the repository's existing workflows, require actions to be pinned to a full-length commit SHA.
 - **Settings → Environments → `cvmfs-publish`**
   - Secret `STRATUM0_SSH_KEY` — the private key authorized on the Stratum 0 hosts.
   - Add `@galaxyproject/tool-installers` as required reviewers and prevent self-review. This is the deploy authorization
@@ -111,7 +110,7 @@ jobs:
       group: cvmfs-test
       labels: cvmfs
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@v7
       - run: |
           set -euo pipefail
           export REPO_STRATUM0=cvmfs0-psu1.galaxyproject.org

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -28,18 +28,17 @@ Two directories, both owned by the runner user, both configurable via the runner
 environment (defaults shown):
 
 ```
-SCRATCH_ROOT=/data/actions-runner/scratch        # per-run overlayfs and CVMFS mounts
-CVMFS_CACHE_ROOT=/data/actions-runner/cvmfs-cache  # persistent CVMFS cache, kept warm between runs
+SCRATCH_ROOT=/data/actions-runner/scratch          # per-run overlayfs and CVMFS mounts
+CVMFS_CACHE_ROOT=/data/actions-runner/cvmfs-cache  # CVMFS cache
 ```
 
 `SCRATCH_ROOT` needs room for a full copy-up of whatever a single run installs. It must **not** be
 set to `$GITHUB_WORKSPACE`: that is the git checkout, and creating the overlay directories inside
 it would pollute the working tree that change detection diffs.
 
-`CVMFS_CACHE_ROOT` is bounded by the `CVMFS_QUOTA_LIMIT` soft limit in `.ci/cvmfs-fuse.conf`,
-currently 8 GB. To reclaim space sooner, check that no job is running and delete the
-per-repository subdirectories under it, or the whole directory — the next run recreates what it
-needs. A cold cache costs one slow run, nothing worse.
+Both hosts are rolled back to a clean snapshot, so neither directory survives between runs and
+every run starts with a cold cache. `CVMFS_QUOTA_LIMIT` in `.ci/cvmfs-fuse.conf` still bounds the
+cache within a run, currently 8 GB.
 
 ## SSH access to the Stratum 0
 
@@ -63,9 +62,12 @@ Create two **organization-level runner groups** that allow only selected workflo
 
 Register separate hosts in the two groups with the labels `self-hosted, Linux, X64, cvmfs`. Do not place a host in
 both groups. The test host executes PR-controlled code, so give it no secrets or SSH/write access to Stratum 0; allow
-only the read-only HTTP access needed by the CVMFS client. Rebuild it from a clean image after untrusted runs. Keep
-exactly one runner in the publish group so its runner queue serializes every deploy without dropping pending runs. The
-publish host must never accept a `pull_request` job.
+only the read-only HTTP access needed by the CVMFS client. Keep exactly one runner in the publish group so its runner
+queue serializes every deploy without dropping pending runs. The publish host must never accept a `pull_request` job.
+
+Both hosts are rolled back to a clean snapshot between runs. On the test host this is what prevents PR-controlled code
+from persisting to a later run; on the publish host it is not load-bearing, but keeping the two identical means there
+is one operational story rather than two.
 
 Install the job-started hook on each host. It removes labeled Galaxy containers, mounts, and scratch directories left
 behind when a job is forcibly terminated:


### PR DESCRIPTION
Stacked fixes for galaxyproject/usegalaxy-tools#1696, prepared by OpenAI Codex at Marius’s request.

This addresses the review findings by:

- isolating PR testing and publishing in separate, selected-workflow organization runner groups;
- documenting required `tool-installers` environment review and CODEOWNER enforcement;
- preserving every deploy through a single publish-runner queue instead of a lossy concurrency group;
- making scratch/container names unique per run attempt and reaping orphaned labeled containers and dirty scratch state;
- making the required `test-install` check report for PRs without tool changes;
- requiring pre-provisioned SSH host keys; and
- updating the stale PR template and runner documentation.

Operational prerequisites before merging the parent PR: provision the `cvmfs-test` and `cvmfs-publish` runner groups on separate hosts, configure selected-workflow access, create the protected `cvmfs-publish` environment with `@galaxyproject/tool-installers` reviewers and `STRATUM0_SSH_KEY`, install verified Stratum 0 host keys, and update branch protection as documented.

Validation:

- `bash -n .ci/github-actions.sh .ci/runner-job-started.sh`
- `actionlint` on both added workflows (custom `cvmfs` label warning ignored)
- `git diff --check`
- ShellCheck comparison confirmed no new warning-level findings in the installer; the cleanup hook is clean.